### PR TITLE
[api] Refactoring API request / response structs

### DIFF
--- a/api/tasks.go
+++ b/api/tasks.go
@@ -10,16 +10,21 @@ type Tasks struct {
 	client *Client
 }
 
+// FSMs wraps the client for task-specific endpoints
+func (c *Client) Tasks() *Tasks {
+	return &Tasks{client: c}
+}
+
 // Definition is used to serialize task definitions
 type Definition struct {
 	// Metadata groups task-related descriptors
-	Metadata *Metadata `yaml:"metadata"`
+	Metadata *DefinitionMetadata `yaml:"metadata"`
 
 	FSM *FSM `yaml:"state_machine"`
 }
 
 // Metadata groups task-related descriptors
-type Metadata struct {
+type DefinitionMetadata struct {
 	// Name is a globally unique name for the task.
 	Name string `yaml:"name"`
 
@@ -49,11 +54,6 @@ type Event struct {
 	Src []string `yaml:"sources"`
 }
 
-// FSMs wraps the client for task-specific endpoints
-func (c *Client) Tasks() *Tasks {
-	return &Tasks{client: c}
-}
-
 type (
 	// TaskDefineRequest is used to serialize a Define request
 	TaskDefineRequest struct {
@@ -62,9 +62,7 @@ type (
 
 	// TaskDefineResponse is used to serialize a Define response
 	TaskDefineResponse struct {
-		Index      uint64
-		Name       string
-		Attributes map[string]string
+		Definition *Definition
 	}
 )
 
@@ -88,8 +86,7 @@ type (
 
 	// TaskListResponse is used to serialize a List response
 	TaskListResponse struct {
-		Len   int
-		Names []string
+		Definitions []*Definition
 	}
 )
 
@@ -109,7 +106,7 @@ type (
 
 	// TaskRunResponse is used to serialize a Run resonse
 	TaskRunResponse struct {
-		InstanceID string
+		Instance *Instance
 	}
 )
 
@@ -132,8 +129,7 @@ type (
 
 	// TaskPsResponse is used to serialize a Ps response
 	TaskPsResponse struct {
-		Len int
-		IDs []string
+		Instances []*Instance
 	}
 )
 

--- a/openstate/fsm.go
+++ b/openstate/fsm.go
@@ -6,8 +6,6 @@ import (
 
 	log "github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/raft"
-
-	"github.com/walkergriggs/openstate/api"
 )
 
 // openstateFSM implements raft.FSM and is used for strongly consistent state
@@ -63,17 +61,13 @@ func (f *openstateFSM) applyDefineTask(reqType MessageType, buf []byte, index ui
 		return err
 	}
 
-	def := &Definition{
-		Name:       req.Definition.Metadata.Name,
-		Attributes: req.Definition.Metadata.Attributes,
-		FSM:        req.Definition.FSM,
-	}
+	def := req.Definition
 
 	if err := def.Validate(); err != nil {
 		return err
 	}
 
-	f.definitions[def.Name] = def
+	f.definitions[def.Metadata.Name] = def
 	return nil
 }
 
@@ -86,16 +80,7 @@ func (f *openstateFSM) applyRunTask(reqType MessageType, buf []byte, index uint6
 		return err
 	}
 
-	fsm, err := api.Ftof(req.Definition.FSM)
-	if err != nil {
-		return err
-	}
-
-	instance := &Instance{
-		ID:         req.InstanceID,
-		Definition: req.Definition,
-		FSM:        fsm,
-	}
+	instance := req.Instance
 
 	f.instances[instance.ID] = instance
 	return nil

--- a/openstate/instance_endpoint.go
+++ b/openstate/instance_endpoint.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-
-	"github.com/walkergriggs/openstate/api"
 )
 
 // taskSpecificRequest routes a request to various functions which apply to an
@@ -27,7 +25,7 @@ func (s *HTTPServer) instanceEvent(resp http.ResponseWriter, req *http.Request, 
 		return nil, err
 	}
 
-	var out api.InstanceEventRequest
+	var out InstanceEventRequest
 	dec := json.NewDecoder(req.Body)
 	if err := dec.Decode(&out); err != nil {
 		return nil, err
@@ -42,8 +40,8 @@ func (s *HTTPServer) instanceEvent(resp http.ResponseWriter, req *http.Request, 
 		return nil, err
 	}
 
-	res := &api.InstanceEventResponse{
-		CurrentState: instance.FSM.State(),
+	res := InstanceEventResponse{
+		Instance: instance,
 	}
 
 	return res, nil

--- a/openstate/structs.go
+++ b/openstate/structs.go
@@ -14,31 +14,80 @@ const (
 	TaskRunRequestType    MessageType = 1
 )
 
-// TaskDefineRequest is used to serialize a task definition request to be sent
-// over Raft logs
-type TaskDefineRequest struct {
-	Definition *api.Definition
-}
+type (
+	// TaskListRequest is used to serialize a List request
+	TaskListRequest struct{}
 
-// TaskRunRequest is used to serialize a task run request to be sent over Raft
-// logs
-type TaskRunRequest struct {
-	InstanceID string
-	Definition *Definition
-}
+	// TaskListResponse is used to serialize a List response
+	TaskListResponse struct {
+		Definitions []*Definition
+	}
+)
+
+type (
+	// TaskDefineRequest is used to serialize a Define request
+	TaskDefineRequest struct {
+		Definition *Definition
+	}
+
+	// TaskDefineResponse is used to serialize a Define response
+	TaskDefineResponse struct {
+		Definition *Definition
+	}
+)
+
+type (
+	// TaskRunRequest is used to serialize a Run request
+	TaskRunRequest struct {
+		Instance *Instance
+	}
+
+	// TaskRunResponse is used to serialize a Run resonse
+	TaskRunResponse struct {
+		Instance *Instance
+	}
+)
+
+type (
+	// TaskPsRequest is used to serialize a Ps request
+	TaskPsRequest struct{}
+
+	// TaskPsResponse is used to serialize a Ps response
+	TaskPsResponse struct {
+		Instances []*Instance
+	}
+)
+
+type (
+	// InstanceRunRequest is used to serialize an Event request
+	InstanceEventRequest struct {
+		EventName string
+	}
+
+	// InstanceEventResponse is used to serialize an Event response
+	InstanceEventResponse struct {
+		Instance *Instance
+	}
+)
 
 // Definition is used to define task workflows.
 type Definition struct {
-	// Name is used to describe the task and all versions,
-	Name string
-
-	// Attributes are opaque descriptors to decorate the task.
-	Attributes map[string]string
+	// Metadata groups task-related descriptors
+	Metadata *DefinitionMetadata
 
 	// FSM is the API's serialized description of a desired finite state machine.
 	// This FSM has no functionality aside from being used to create an instance's
 	// fsm.FSM.
 	FSM *api.FSM
+}
+
+// Metadata groups task-related descriptors
+type DefinitionMetadata struct {
+	// Name is used to describe the task and all versions,
+	Name string
+
+	// Attributes are opaque descriptors to decorate the task.
+	Attributes map[string]string
 }
 
 // Instance is used to run a defined workflow.
@@ -60,7 +109,7 @@ type Instance struct {
 // Validate is used to check the validity of a task object. Validate is not
 // considered comprehensive at this time.
 func (d *Definition) Validate() error {
-	if d.Name == "" {
+	if d.Metadata.Name == "" {
 		return fmt.Errorf("Missing name")
 	}
 


### PR DESCRIPTION
This PR:
- decouples the API / Openstate core endpoint response structs
- adds endpoints response and requests structs and an intermediary