### PR TITLE
[cmd] Use UI to format responses

### DIFF
--- a/api/instances.go
+++ b/api/instances.go
@@ -3,6 +3,8 @@ package api
 import (
 	"fmt"
 	"net/url"
+	"strings"
+	"text/tabwriter"
 
 	"github.com/walkergriggs/openstate/fsm"
 )
@@ -31,6 +33,38 @@ type Instance struct {
 	// FSM is the graph defined, event driven state machine which provides the
 	// instances backing functionality.
 	FSM *fsm.FSM
+}
+
+// Summarize is used to derrive an InstanceSummary from an Instance object.
+func (i *Instance) Summarize() *InstanceSummary {
+	return &InstanceSummary{
+		ID:         i.ID,
+		Definition: i.Definition.Metadata.Name,
+		Current:    i.FSM.State(),
+	}
+}
+
+// InstanceSummary is used as a point-in-time summary or the instance object.
+// The InstanceSummary doesn't expose any functionality itself, but is used to
+// convey high-level information to clients.
+type InstanceSummary struct {
+	ID         string
+	Definition string
+	Current    string
+}
+
+// String is used to provide a string representation of an InstanceSummary. The
+// key/values are columar and tab aligned.
+func (i *InstanceSummary) String() string {
+	builder := &strings.Builder{}
+	writer := tabwriter.NewWriter(builder, 0, 0, 1, ' ', 0)
+
+	fmt.Fprintf(writer, "ID\t = %s\n", i.ID)
+	fmt.Fprintf(writer, "Definition\t = %s\n", i.Definition)
+	fmt.Fprintf(writer, "Current State\t = %v\n", i.Current)
+	writer.Flush()
+
+	return builder.String()
 }
 
 type (

--- a/cmd/instance.go
+++ b/cmd/instance.go
@@ -7,7 +7,7 @@ import (
 func NewCmdInstance() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "instance",
-		Short: "instance groups instance-related subcommands",
+		Short: "Groups instance-related subcommands",
 	}
 
 	cmd.AddCommand(NewCmdInstanceEvent())

--- a/cmd/instance_event.go
+++ b/cmd/instance_event.go
@@ -63,7 +63,7 @@ func (o *InstanceEventOptions) Run() {
 		return
 	}
 
-	fmt.Printf("%+v\n", *res)
+	o.Meta.UI.Output(res.Instance.Summarize().String())
 }
 
 func (o *InstanceEventOptions) Name() string {

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -195,7 +195,8 @@ func NewCmdServer() *cobra.Command {
 	config := o.config
 
 	cmd := &cobra.Command{
-		Use: "server",
+		Use:   "server",
+		Short: "Runs an OpenState server",
 		Run: func(cmd *cobra.Command, args []string) {
 			if err := o.Complete(cmd, args); err != nil {
 				return

--- a/cmd/task.go
+++ b/cmd/task.go
@@ -7,7 +7,7 @@ import (
 func NewCmdTask() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "task",
-		Short: "task groups task-related subcommands",
+		Short: "Groups task-related subcommands",
 	}
 
 	cmd.AddCommand(NewCmdTaskDefine())

--- a/cmd/task_define.go
+++ b/cmd/task_define.go
@@ -85,7 +85,7 @@ func (o *TaskDefineOptions) Run() {
 		return
 	}
 
-	fmt.Printf("%+v\n", *res)
+	o.Meta.UI.Output(res.Definition.Summarize().String())
 }
 
 func (o *TaskDefineOptions) Name() string {

--- a/cmd/task_list.go
+++ b/cmd/task_list.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/spf13/cobra"
+
+	"github.com/walkergriggs/openstate/api"
 )
 
 func TaskListUsageTemplate() string {
@@ -49,7 +51,9 @@ func (o *TaskListOptions) Run() {
 		return
 	}
 
-	fmt.Printf("%+v\n", *res)
+	table := FormatTable(formatDefinitions(res.Definitions))
+
+	o.UI.Output(table)
 }
 
 func (o *TaskListOptions) Name() string {
@@ -72,4 +76,14 @@ func NewCmdTaskList() *cobra.Command {
 	cmd.SetUsageTemplate(TaskListUsageTemplate())
 
 	return cmd
+}
+
+func formatDefinitions(definitions []*api.Definition) (data [][]string) {
+	data = append(data, []string{"Name"})
+
+	for _, def := range definitions {
+		data = append(data, []string{def.Metadata.Name})
+	}
+
+	return
 }

--- a/cmd/task_ps.go
+++ b/cmd/task_ps.go
@@ -7,6 +7,8 @@ import (
 
 	"github.com/mitchellh/cli"
 	"github.com/spf13/cobra"
+
+	"github.com/walkergriggs/openstate/api"
 )
 
 func TaskPsUsageTemplate() string {
@@ -59,7 +61,9 @@ func (o *TaskPsOptions) Run() {
 		return
 	}
 
-	fmt.Printf("%+v\n", *res)
+	table := FormatTable(formatInstances(res.Instances))
+
+	o.UI.Output(table)
 }
 
 func (o *TaskPsOptions) Name() string {
@@ -86,4 +90,14 @@ func NewCmdTaskPs() *cobra.Command {
 	cmd.SetUsageTemplate(TaskPsUsageTemplate())
 
 	return cmd
+}
+
+func formatInstances(instances []*api.Instance) (data [][]string) {
+	data = append(data, []string{"ID", "Definition", "State"})
+
+	for _, i := range instances {
+		data = append(data, []string{i.ID, i.Definition.Metadata.Name, i.FSM.State()})
+	}
+
+	return
 }

--- a/cmd/task_run.go
+++ b/cmd/task_run.go
@@ -61,7 +61,7 @@ func (o *TaskRunOptions) Run() {
 		return
 	}
 
-	fmt.Printf("%+v\n", *res)
+	o.Meta.UI.Output(res.Instance.Summarize().String())
 }
 
 func (o *TaskRunOptions) Name() string {


### PR DESCRIPTION
This PR:
- Formats definition and instance tables using the tablewriter helpers
- Adds instance and definition summary structs
- Formats summary structs with tabwriter for tab-aligned columns